### PR TITLE
cast from iso8601

### DIFF
--- a/lib/ecto/date_time_range/utc_date_time.ex
+++ b/lib/ecto/date_time_range/utc_date_time.ex
@@ -99,6 +99,17 @@ defmodule Ecto.DateTimeRange.UTCDateTime do
   @impl Ecto.Type
   @doc section: :ecto_type
   @doc "Converts user-provided data (for example from a form) to the Elixir term."
+  def cast(%{start_at: lower_iso8601, end_at: upper_iso8601} = attrs)
+       when is_binary(lower_iso8601) and is_binary(upper_iso8601) do
+     with {:ok, lower, _} <- DateTime.from_iso8601(lower_iso8601),
+          {:ok, upper, _} <- DateTime.from_iso8601(upper_iso8601) do
+       cast(Map.merge(attrs, %{start_at: lower, end_at: upper}))
+     else
+       _ ->
+         {:error, message: "unable to read start and/or end times"}
+     end
+   end
+
   def cast(%{start_at: lower, end_at: upper, tz: tz}) do
     case apply_func({lower, upper}, &Ecto.Type.cast(:naive_datetime, &1)) do
       {:ok, {lower, upper}} ->


### PR DESCRIPTION
This supports the pickup.slot migration since we want to cast from iso in the admin update pickup details form. Feels good to have in general too, but if we want to minimize changes to DateTimeRange we could work around it by requiring that changeset attrs are DateTimes.